### PR TITLE
Fixing typo in persistence doc

### DIFF
--- a/redis.docset/Contents/Resources/Documents/topics/persistence.html
+++ b/redis.docset/Contents/Resources/Documents/topics/persistence.html
@@ -296,7 +296,7 @@ for best results.</li>
 </ul>
 
 
-<p>It is important to understand that this systems can easily fail if not coded
+<p>It is important to understand that this system can easily fail if not coded
 in the right way. At least make absolutely sure that after the transfer is
 completed you are able to verify the file size (that should match the one of
 the file you copied) and possibly the SHA1 sum if you are using a VPS.</p>


### PR DESCRIPTION
Related: same typofix in .md doc https://github.com/antirez/redis-doc/pull/512